### PR TITLE
improve security and fix a few minor issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["mktemp", "temp", "file", "dir", "directory"]
 license = "MPL-2.0"
 
 [dependencies]
-uuid = "0.1.18"
+uuid = { version = "0.4.0", features = ["v4"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,6 @@ impl Temp {
 
     fn create_dir(&self) -> io::Result<()> {
         let mut builder = fs::DirBuilder::new();
-        builder.recursive(true);
 
         #[cfg(unix)]
         builder.mode(0o700);
@@ -278,17 +277,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn temp_dir_only_readable_by_owner() {
-        let test_dir = Temp::new_dir().unwrap();
-        let mut subdir = test_dir.as_ref().to_owned();
-        subdir.push("sub");
-
-        let temp_dir = Temp::new_dir_in(&subdir).unwrap();
-        assert_dir_permissions(temp_dir.as_ref());
-        assert_dir_permissions(&subdir);
-    }
-
-    #[cfg(unix)]
-    fn assert_dir_permissions(dir: &Path) {
+        let dir = Temp::new_dir().unwrap();
         let mode = fs::metadata(dir).unwrap().mode();
         assert_eq!(0o700, mode & 0o777)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,12 +298,12 @@ mod tests {
 
         match Temp::new_file_in(&no_such_dir) {
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => (),
-            _ => panic!()
+            _ => panic!(),
         }
 
         match Temp::new_dir_in(&no_such_dir) {
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => (),
-            _ => panic!()
+            _ => panic!(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ fn create_path_in(path: PathBuf) -> PathBuf {
     let mut path = path;
     let dir_uuid = Uuid::new_v4();
 
-    path.push(dir_uuid.to_simple_string());
+    path.push(dir_uuid.simple().to_string());
     path
 }
 


### PR DESCRIPTION
Took a look at the default RNG used by the uuid crate and updated it while on it. I'm not a specialist for RNGs but a far as I can tell it should be strong enough that DoS are very unlikely to succeed. However, in the case of directories I decided to no longer recursively create the directory. When recursively creating it, "already exists" errors are ignored, potentially allowing an adversary to create the directory earlier than we do and thereby gaining full access to the directory. This would be far worse than DoS.

This is related to #3.