### PR TITLE
Dont panic dropping nonexisting file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,15 @@ mod tests {
         }
     }
 
+
+    #[test]
+    #[should_panic]
+    fn it_should_panic_on_drop_non_existing_file() {
+        let temp_file = Temp::new_file().unwrap();
+        let path = temp_file.to_path_buf();
+        fs::remove_file(path).unwrap();
+    }
+
     #[test]
     fn it_should_not_drop_released_file() {
         let path_buf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,56 +59,37 @@ impl Temp {
     pub fn new_dir() -> io::Result<Self> {
         let path = create_path();
         Self::create_dir(&path)?;
-
-        let temp = Temp {
-            path: path,
-            temp_type: TempType::Dir,
-            released: false,
-        };
-
-        Ok(temp)
+        Ok(Self::new(path, TempType::Dir))
     }
 
     /// Create a new temporary directory in an existing directory
     pub fn new_dir_in(directory: &Path) -> io::Result<Self> {
         let path = create_path_in(directory.to_path_buf());
         Self::create_dir(&path)?;
-
-        let temp = Temp {
-            path: path,
-            temp_type: TempType::Dir,
-            released: false,
-        };
-
-        Ok(temp)
+        Ok(Self::new(path, TempType::Dir))
     }
 
     /// Create a new temporary file in an existing directory
     pub fn new_file_in(directory: &Path) -> io::Result<Self> {
         let path = create_path_in(directory.to_path_buf());
         Self::create_file(&path)?;
-
-        let temp = Temp {
-            path: path,
-            temp_type: TempType::File,
-            released: false,
-        };
-
-        Ok(temp)
+        Ok(Self::new(path, TempType::File))
     }
 
     /// Create a temporary file.
     pub fn new_file() -> io::Result<Self> {
         let path = create_path();
         Self::create_file(&path)?;
+        Ok(Self::new(path, TempType::File))
+    }
 
-        let temp = Temp {
-            path: path,
-            temp_type: TempType::File,
+    /// Internal helper constructor
+    fn new(path: PathBuf, temp_type: TempType) -> Self {
+        Temp {
+            path,
+            temp_type,
             released: false,
-        };
-
-        Ok(temp)
+        }
     }
 
     /// Return this temporary file or directory as a PathBuf.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@ enum TempType {
 #[derive(Clone)]
 pub struct Temp {
     path: PathBuf,
-    _type: TempType,
-    _released: bool,
+    temp_type: TempType,
+    released: bool,
 }
 
 fn create_path() -> PathBuf {
@@ -62,8 +62,8 @@ impl Temp {
 
         let temp = Temp {
             path: path,
-            _type: TempType::Dir,
-            _released: false,
+            temp_type: TempType::Dir,
+            released: false,
         };
 
         Ok(temp)
@@ -76,8 +76,8 @@ impl Temp {
 
         let temp = Temp {
             path: path,
-            _type: TempType::Dir,
-            _released: false,
+            temp_type: TempType::Dir,
+            released: false,
         };
 
         Ok(temp)
@@ -90,8 +90,8 @@ impl Temp {
 
         let temp = Temp {
             path: path,
-            _type: TempType::File,
-            _released: false,
+            temp_type: TempType::File,
+            released: false,
         };
 
         Ok(temp)
@@ -104,8 +104,8 @@ impl Temp {
 
         let temp = Temp {
             path: path,
-            _type: TempType::File,
-            _released: false,
+            temp_type: TempType::File,
+            released: false,
         };
 
         Ok(temp)
@@ -140,7 +140,7 @@ impl Temp {
     /// assert!(path_buf.exists());
     /// ```
     pub fn release(&mut self) {
-        self._released = true;
+        self.released = true;
     }
 
     fn create_file(path: &Path) -> io::Result<()> {
@@ -182,8 +182,8 @@ impl AsRef<Path> for Temp {
 impl Drop for Temp {
     fn drop(&mut self) {
         // Drop is blocking (make non-blocking?)
-        if !self._released {
-            let result = match self._type {
+        if !self.released {
+            let result = match self.temp_type {
                 TempType::File => self.remove_file(),
                 TempType::Dir => self.remove_dir(),
             };


### PR DESCRIPTION
Fixes #8 

I find it very limiting that the `Drop` impl always panic on removal failure, even if the removal failed just because the file was already gone. This becomes extra strange since `Temp` implements `Clone`, thus all but the first dropped clone will panic unless you `release()` it. I would like a behavior where every clone tries to remove the file, but if it was not the first one to be dropped (ie. the file is already gone) that should be fine.

Personally I would like the default to be to not panic in this instance. But to not break the API I left it to default to `true`. If you agree with changing the default I can do that!

I added tests to test the expected behavior in the default form and the non-panicing setting.

Also removed some code duplication.