### PR TITLE
Don't derive Clone, it will cause issues with drop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Temp {
     path: PathBuf,
 }


### PR DESCRIPTION
The issue here is that dropping the first clone causes file to be removed, dropping second clone causes panic.
Since temporary file is not something that can be meaningfully cloned, I think it is better to not derive it and leave up to the user to wrap it in `Arc` or something like that when necessary.