### PR TITLE
Allow creating files with extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name          = "mktemp"
-description   = "mktemp files and directories"
-homepage      = "https://docs.rs/mktemp"
+name = "mktemp"
+description = "mktemp files and directories"
+homepage = "https://docs.rs/mktemp"
 documentation = "https://docs.rs/mktemp"
-repository    = "https://github.com/samgiles/rs-mktemp"
-version       = "0.5.0"
-authors       = ["Sam Giles <sam.e.giles@gmail.com>"]
-keywords      = ["mktemp", "temp", "file", "dir", "directory"]
-license       = "MPL-2.0"
+repository = "https://github.com/samgiles/rs-mktemp"
+version = "0.5.1"
+authors = ["Sam Giles <sam.e.giles@gmail.com>"]
+keywords = ["mktemp", "temp", "file", "dir", "directory"]
+license = "MPL-2.0"
 
 [dependencies]
 uuid = { version = "~1.2", features = ["v4"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,6 @@ fn create_path_with_ext(extension: &str) -> PathBuf {
 }
 
 fn create_path_in(path: PathBuf) -> PathBuf {
-    // let mut path = path;
-    // let dir_uuid = Uuid::new_v4();
-
-    // path.push(dir_uuid.simple().to_string());
-    // path
     create_path_with_ext_in(path, "")
 }
 


### PR DESCRIPTION
This adds support for creating files with predefined extensions. This allows temporary files to be created for opening in text editors that recognize filetypes (e.g. `vim` or `neovim`). See #13.

Two new public functions are added:
- `new_file_with_extension`
- `new_file_with_extension_in`

I've also tweaked the `create_path*` functions to allow for this functionality and added tests.
