### PR TITLE
Updated uuid from ~1.2 to ~1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ keywords      = ["mktemp", "temp", "file", "dir", "directory"]
 license       = "MPL-2.0"
 
 [dependencies]
-uuid = { version = "~1.2", features = ["v4"] }
+uuid = { version = "~1.4", features = ["v4"] }


### PR DESCRIPTION
Updated to depend on uuid ~1.4. Passed `cargo test`.