### PR TITLE
Set MSRV in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ version       = "0.5.1"
 authors       = ["Sam Giles <sam.e.giles@gmail.com>"]
 keywords      = ["mktemp", "temp", "file", "dir", "directory"]
 license       = "MPL-2.0"
+rust-version  = "1.57.0"
 
 [dependencies]
 uuid = { version = "~1.4", features = ["v4"] }


### PR DESCRIPTION
The current MSRV is 1.57.0, the same as the `uuid ~1.4` dependency.
