### PR TITLE
Update uuid to 1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version       = "0.5.1"
 authors       = ["Sam Giles <sam.e.giles@gmail.com>"]
 keywords      = ["mktemp", "temp", "file", "dir", "directory"]
 license       = "MPL-2.0"
-rust-version  = "1.57.0"
+rust-version  = "1.60.0"
 
 [dependencies]
-uuid = { version = "~1.5", features = ["v4"] }
+uuid = { version = "~1.6", features = ["v4"] }


### PR DESCRIPTION
This bumps the MSRV to 1.60.0. Rust 1.60.0 has been released almost two years ago (Apr 2022), anyone still using it will not upgrade their dependencies anyway as most packages will not support such an ancient version.
